### PR TITLE
Add ShippingProvider.Tests project with unit tests

### DIFF
--- a/ShippingProvider.Tests/Services/ShippingService_Tests.cs
+++ b/ShippingProvider.Tests/Services/ShippingService_Tests.cs
@@ -1,0 +1,185 @@
+﻿using Microsoft.Extensions.Configuration;
+using Moq;
+using Moq.Protected;
+using ShippingProvider.DTO.ServicePointDTOs;
+using ShippingProvider.DTO.TransitTimeDTOs;
+using ShippingProvider.Services;
+using System.Net;
+using System.Text.Json;
+
+namespace ShippingProvider.Tests.Services;
+
+public class ShippingService_Tests
+{
+    private readonly Mock<IConfiguration> _mockConfiguration;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+
+    public ShippingService_Tests()
+    {
+        _mockConfiguration = new Mock<IConfiguration>();
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+    }
+
+    [Fact]
+    public async Task GetNearestServicePointsAsync_ReturnsServicePoints_WhenSuccessful()
+    {
+        // Arrange
+        var postalCode = "12345";
+        var numberOfServicePoints = 3;
+        var expectedResponse = new ServicePointInformationResponseWrapper
+        {
+            ServicePointInformationResponse = new ServicePointInformationResponse
+            {
+                ServicePoints = new List<ServicePoints>
+                {
+                    new ServicePoints
+                    {
+                        Name = "Test ServicePoint",
+                        ServicePointId = "SP1",
+                        VisitingAddress = new VisitingAddress
+                        {
+                            CountryCode = "SE",
+                            City = "Stockholm",
+                            StreetName = "Main St",
+                            StreetNumber = "10",
+                            PostalCode = "12345"
+                        }
+                    }
+                }
+            }
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse);
+        var baseUrl = "https://example.com/";
+
+        _mockConfiguration.Setup(c => c["PostNord:BaseUrl"]).Returns(baseUrl);
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri!.ToString().StartsWith(baseUrl)),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonResponse)
+            });
+
+        var shippingService = new ShippingService(_httpClient, "secretKey", _mockConfiguration.Object);
+
+        // Act
+        var result = await shippingService.GetNearestServicePointsAsync(postalCode, numberOfServicePoints);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.ServicePointInformationResponse.ServicePoints);
+        Assert.Equal("Test ServicePoint", result.ServicePointInformationResponse.ServicePoints.First().Name);
+        Assert.Equal("Stockholm", result.ServicePointInformationResponse.ServicePoints.First().VisitingAddress.City);
+    }
+
+    [Fact]
+    public async Task GetTransitTimesAsync_ReturnsTransitTimes_WhenSuccessful()
+    {
+        // Arrange
+        var request = new TransitTimeRequest { DestinationPostalCode = "14142" };
+        var expectedResponse = new List<TransitTimeResponse>
+        {
+            new TransitTimeResponse
+            {
+                timeOfDeparture = "08:00",
+                timeOfArrival = "12:00",
+                serviceInformation = new ServiceInformation { name = "Express" }
+            }
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse);
+        var baseUrl = "https://example.com/";
+
+        _mockConfiguration.Setup(c => c["PostNord:BaseUrl"]).Returns(baseUrl);
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri!.ToString().StartsWith(baseUrl)),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonResponse)
+            });
+
+        var shippingService = new ShippingService(_httpClient, "secretKey", _mockConfiguration.Object);
+
+        // Act
+        var result = await shippingService.GetTransitTimesAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("08:00", result.First().timeOfDeparture);
+        Assert.Equal("Express", result.First().serviceInformation.name);
+    }
+
+    [Fact]
+    public async Task GetNearestServicePointsAsync_ThrowsException_WhenRequestFails()
+    {
+        // Arrange
+        var postalCode = "12345";
+        var numberOfServicePoints = 3;
+        var baseUrl = "https://example.com/";
+
+        _mockConfiguration.Setup(c => c["PostNord:BaseUrl"]).Returns(baseUrl);
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("Bad Request")
+            });
+
+        var shippingService = new ShippingService(_httpClient, "secretKey", _mockConfiguration.Object);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(() =>
+            shippingService.GetNearestServicePointsAsync(postalCode, numberOfServicePoints));
+        Assert.Contains("Failed to fetch service points", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetTransitTimesAsync_ThrowsException_WhenRequestFails()
+    {
+        // Arrange
+        var request = new TransitTimeRequest { DestinationPostalCode = "14142" };
+        var baseUrl = "https://example.com/";
+
+        _mockConfiguration.Setup(c => c["PostNord:BaseUrl"]).Returns(baseUrl);
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent("Server Error")
+            });
+
+        var shippingService = new ShippingService(_httpClient, "secretKey", _mockConfiguration.Object);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(() =>
+            shippingService.GetTransitTimesAsync(request));
+        Assert.Contains("Failed to fetch service points", exception.Message);
+    }
+}

--- a/ShippingProvider.Tests/ShippingProvider.Tests.csproj
+++ b/ShippingProvider.Tests/ShippingProvider.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ShippingProvider\ShippingProvider.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/ShippingProvider.sln
+++ b/ShippingProvider.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShippingProvider", "ShippingProvider\ShippingProvider.csproj", "{B6E7C49B-7418-4146-906C-4C74E1A31614}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShippingProvider.Tests", "ShippingProvider.Tests\ShippingProvider.Tests.csproj", "{37C0E18E-2999-43A3-B09B-7B5A79B1F70F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{B6E7C49B-7418-4146-906C-4C74E1A31614}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6E7C49B-7418-4146-906C-4C74E1A31614}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6E7C49B-7418-4146-906C-4C74E1A31614}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37C0E18E-2999-43A3-B09B-7B5A79B1F70F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37C0E18E-2999-43A3-B09B-7B5A79B1F70F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37C0E18E-2999-43A3-B09B-7B5A79B1F70F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37C0E18E-2999-43A3-B09B-7B5A79B1F70F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduce a new test project `ShippingProvider.Tests` to the solution file `ShippingProvider.sln`, targeting .NET 9.0. Add package references for testing, including `coverlet.collector`, `Microsoft.NET.Test.Sdk`, `Moq`, `xunit`, and `xunit.runner.visualstudio`.

Add `ShippingService_Tests` class with unit tests for `ShippingService` using Moq for mocking and Xunit for assertions. Tests cover scenarios for successful retrieval of service points and transit times, as well as handling failed requests.